### PR TITLE
Fix code snippet layout

### DIFF
--- a/_wiki/BioJava_CookBook_Core_Overview.md
+++ b/_wiki/BioJava_CookBook_Core_Overview.md
@@ -72,10 +72,8 @@ We really want to make it easy to create a sequence and what could be
 easier than using a String.
 
 ```java
-
-`           ProteinSequence proteinSequence = new ProteinSequence("ARNDCEQGHILKMFPSTWYVBZJX");`  
-`           DNASequence dnaSequence = new DNASequence("ATCG");`
-
+           ProteinSequence proteinSequence = new ProteinSequence("ARNDCEQGHILKMFPSTWYVBZJX");
+           DNASequence dnaSequence = new DNASequence("ATCG");
 ```
 
 The storage of the sequence data is defined by the Sequence interface
@@ -110,8 +108,8 @@ some level of api changes as we improve the overall design.
 
 ```java
 
-`           UniprotProxySequenceReader`<AminoAcidCompound>` uniprotSequence = new UniprotProxySequenceReader`<AminoAcidCompound>`("YA745_GIBZE", AminoAcidCompoundSet.getAminoAcidCompoundSet());`  
-`           ProteinSequence proteinSequence = new ProteinSequence(uniprotSequence);`
+           UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<AminoAcidCompound>("YA745_GIBZE", AminoAcidCompoundSet.getAminoAcidCompoundSet());
+           ProteinSequence proteinSequence = new ProteinSequence(uniprotSequence);
 
 ```
 
@@ -124,17 +122,15 @@ but is very specific to learning the location of the sequence data in
 the file.
 
 ```java
+           File file = new File(inputFile);
+           FastaReader<ProteinSequence,AminoAcidCompound> fastaProxyReader = new FastaReader<ProteinSequence,AminoAcidCompound>(file, new GenericFastaHeaderParser<ProteinSequence,AminoAcidCompound>(), new FileProxyProteinSequenceCreator(file, AminoAcidCompoundSet.getAminoAcidCompoundSet()));
+           LinkedHashMap<String,ProteinSequence> proteinProxySequences = fastaProxyReader.process();
 
-`           File file = new File(inputFile);`  
-`           FastaReader`<ProteinSequence,AminoAcidCompound>` fastaProxyReader = new FastaReader`<ProteinSequence,AminoAcidCompound>`(file, new GenericFastaHeaderParser`<ProteinSequence,AminoAcidCompound>`(), new FileProxyProteinSequenceCreator(file, AminoAcidCompoundSet.getAminoAcidCompoundSet()));`  
-`           LinkedHashMap`<String,ProteinSequence>` proteinProxySequences = fastaProxyReader.process();`
-
-`           for(String key : proteinProxySequences.keySet()){`  
-`               ProteinSequence proteinSequence = proteinProxySequences.get(key);`  
-`               System.out.println(key);`  
-`               System.out.println(proteinSequence.toString());`  
-`           }`
-
+           for(String key : proteinProxySequences.keySet()){
+               ProteinSequence proteinSequence = proteinProxySequences.get(key);
+               System.out.println(key);
+               System.out.println(proteinSequence.toString());
+           }
 ```
 
 In the above example a FastaReader class is created where we abstract
@@ -171,10 +167,8 @@ code. The following code shows the use of FastaReaderHelper and
 FastaWriterHelper.
 
 ```java
-
-`       LinkedHashMap`<String, DNASequence>` dnaSequences = FastaReaderHelper.readFastaDNASequence(new File("454Scaffolds.fna"));`  
-`       FastaWriterHelper.writeNucleotideSequence(new File("454Scaffolds-1.fna"),dnaSequences.values());`
-
+       LinkedHashMap<String, DNASequence> dnaSequences = FastaReaderHelper.readFastaDNASequence(new File("454Scaffolds.fna"));
+       FastaWriterHelper.writeNucleotideSequence(new File("454Scaffolds-1.fna"),dnaSequences.values());
 ```
 
 Working with Sequence Objects
@@ -204,17 +198,18 @@ Avoid using any kind of String method to do this since String operations
 are costly in BioJava (due to the String conversion that must be
 applied). Here is an example on how to do it for any Sequence object.
 
-```java List<Sequence<AminoAcidCompound>\> translations =
+```java
+List<Sequence<AminoAcidCompound>> translations =
 populateFromSomewhere(); Collections.sort(translations, new
-Comparator<Sequence<? extends Compound>\>() {
+Comparator<Sequence<? extends Compound>>() {
 
-`public int compare(Sequence`<? extends Compound>` o1, Sequence`<? extends Compound>` o2) {`  
-`  Integer o1Length = o1.getLength();`  
-`  Integer o2Length = o2.getLength();`  
-`  return o1Length.compareTo(o2Length);`  
-`}`
-
-}); ```
+public int compare(Sequence<? extends Compound> o1, Sequence<? extends Compound> o2) {  
+  Integer o1Length = o1.getLength();  
+  Integer o2Length = o2.getLength();  
+  return o1Length.compareTo(o2Length);  
+}
+});
+```
 
 Note our usage of the generic type to capture Sequence objects of any
 type since the assessment of length is something which can be applied to
@@ -241,9 +236,7 @@ non-ambiguity CompoundSets with Codon table 1 in Frame 1 in the forward
 orientation.
 
 ```java
-
-` ProteinSequence protein = new DNASequence("ATG").getRNASequence().getProteinSequence();`
-
+ProteinSequence protein = new DNASequence("ATG").getRNASequence().getProteinSequence();
 ```
 
 ### Translating in a Different Frame
@@ -257,11 +250,9 @@ object when we request the RNA. Multiple frames of translations are
 possible but see later on.
 
 ```java
-
-` DNASequence dna = new DNASequence("AATG");`  
-` RNASequence rna = dna.getRNASequence(Frame.TWO);`  
-` ProteinSequence protein = rna.getProteinSequence();`
-
+DNASequence dna = new DNASequence("AATG");  
+RNASequence rna = dna.getRNASequence(Frame.TWO);  
+ProteinSequence protein = rna.getProteinSequence();
 ```
 
 ### Translating in Multiple Frames
@@ -273,10 +264,11 @@ translation in. The following example attempts to translate a sequence
 in all three forward frames. The code returns a map of the results keyed
 by their frame.
 
-```java TranscriptionEngine te = TranscriptionEngine.getDefault();
+```java 
+TranscriptionEngine te = TranscriptionEngine.getDefault();
 Frame[] frames = Frame.getForwardFrames();
-Map<Frame, Sequence<AminoAcidCompound>\> results =
-te.multipleFrameTranslation(dna, frames); ```
+Map<Frame, Sequence<AminoAcidCompound>> results = te.multipleFrameTranslation(dna, frames); 
+```
 
 Using this we can replicate the functionality found in EMBOSS' transeq
 package.
@@ -295,18 +287,18 @@ will build an engine to
 -   Convert any initiating amino acid which is not methionine into one
 -   Trim stops
 
-```java TranscriptionEngine.Builder b = new
-TranscriptionEngine.Builder(); b.table(11).initMet(true).trimStop(true);
-TranscriptionEngine engine = b.build(); ```
+```java 
+TranscriptionEngine.Builder b = new TranscriptionEngine.Builder(); 
+b.table(11).initMet(true).trimStop(true);
+TranscriptionEngine engine = b.build(); 
+```
 
 This can be handed to the translation methods like so:
 
 ```java
-
-` DNASequence dna = new DNASequence("ATG");`  
-` RNASequence rna = dna.getRNASequence(engine);`  
-` ProteinSequence protein = rna.getProteinSequence(engine);`
-
+DNASequence dna = new DNASequence("ATG");  
+RNASequence rna = dna.getRNASequence(engine);  
+ProteinSequence protein = rna.getProteinSequence(engine);
 ```
 
 The translation can be started from the TranscriptionEngine directly
@@ -314,15 +306,13 @@ except this results in more general objects (you will get back objects
 which implement the Sequence interface and not the true object type).
 
 ```java
-
-` DNASequence dna = new DNASequence("ATG");`  
-` TranscriptionEngine engine = TranscriptionEngine.getDefault(); //Get the default engine`  
-` Sequence`<NucleotideCompound>` rna = engine.getDnaRnaTranslator().createSequence(dna);`  
-` Sequence`<AminoAcidCompound>` protein = engine.getRnaAminoAcidTranslator().createSequence(rna);`  
-` `  
-` //Or to jump to it straight away use this method (coming soon)`  
-` Sequence`<AminoAcidCompound>` protein = engine.translate(dna);`
-
+DNASequence dna = new DNASequence("ATG");  
+TranscriptionEngine engine = TranscriptionEngine.getDefault(); //Get the default engine  
+Sequence<NucleotideCompound> rna = engine.getDnaRnaTranslator().createSequence(dna);  
+Sequence<AminoAcidCompound> protein = engine.getRnaAminoAcidTranslator().createSequence(rna);  
+  
+//Or to jump to it straight away use this method (coming soon)  
+Sequence<AminoAcidCompound> protein = engine.translate(dna);
 ```
 
 ### Codon Tables


### PR DESCRIPTION
Removed unnecessary '`' and '\' characters in code snippets.
Made sure the text is rendered correctly and code blocks are detected.