### PR TITLE
Removing biojava-dev list

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,24 +76,16 @@ layout: landing
 					<section id="three" class="wrapper style1 special">
 						<div class="inner">
 							<header class="major">
-							  <h2>Mailing lists</h2>
+							  <h2>Mailing list</h2>
 							  <p>
-
-							    BioJava has two main mailing lists.
+							    Questions, comments, and communications regarding BioJava can be made either on github or on the BioJava mailing list:
 							    </p>
 							</header>
 							  <ul class="icons major">
-							    <li><span class="icon fa-users major style1"></span>
+							    <li><span class="icon fa-envelope-o major style1"></span>
 								<a href="/wiki/BioJava:MailingLists/">
 								  <span class="label">biojava-l</span>
 							        </a>  general discussion list
-							    </li>
-							    <li><span class="icon fa-envelope-o major style2">
-
-							      </span>
-<a href="/wiki/BioJava:MailingLists/">
-								  <span class="label">biojava-dev</span>
-								</a> developers list
 							    </li>
 							  </ul>
 


### PR DESCRIPTION
The biojava-dev list will be merged into biojava-l in the future. See biojava/biojava#717