### PR TITLE
Improve website navigation and appearance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,7 @@
 
 # Site settings
 title: BioJava
-description: |
-  BioJava is an open-source project
-  dedicated to providing a Java framework
-  for processing biological data.
+description: The open-source Java framework for bioinformatics
 owner: BioJava
 first_published: 2000
 email: biojava-l@biojava.org

--- a/_includes/citation-2000.md
+++ b/_includes/citation-2000.md
@@ -1,0 +1,4 @@
+**BioJava: open source components for bioinformatics**<br/>
+*Matthew Pocock; Thomas Down; Tim Hubbard* <br/>
+[ACM SIGBIO Newsletter (2000) 20 (2): 10-12.](https://dl.acm.org/citation.cfm?id=360266) <br/>
+[![doi](https://img.shields.io/badge/doi-10.1145%2360262.360266-blue.svg?style=flat)](https://dl.acm.org/citation.cfm?id=360266)

--- a/_includes/citation-2008.md
+++ b/_includes/citation-2008.md
@@ -1,0 +1,4 @@
+**BioJava: an open-source framework for bioinformatics**<br/>
+*R. C. G. Holland, T. A. Down, M. Pocock, A. Prlić, D. Huen, K. James, S. Foisy, A. Dräger, A. Yates, M. Heuer, M. J. Schreiber* <br/>
+[Bioinformatics (2008) 24 (18): 2096–2097.](https://academic.oup.com/bioinformatics/article/24/18/2096/192730) <br/>
+[![doi](https://img.shields.io/badge/doi-10.1093%2Fbioinformatics%2btn397-blue.svg?style=flat)](https://academic.oup.com/bioinformatics/article/24/18/2096/192730) [![pubmed](https://img.shields.io/badge/pubmed-18689808-blue.svg?style=flat)](http://www.ncbi.nlm.nih.gov/pubmed/18689808)

--- a/_includes/citation-2012.md
+++ b/_includes/citation-2012.md
@@ -1,0 +1,4 @@
+**BioJava: an open-source framework for bioinformatics in 2012**<br/>
+*Andreas Prlic; Andrew Yates; Spencer E. Bliven; Peter W. Rose; Julius Jacobsen; Peter V. Troshin; Mark Chapman; Jianjiong Gao; Chuan Hock Koh; Sylvain Foisy; Richard Holland; Gediminas Rimsa; Michael L. Heuer; H. Brandstatter-Muller; Philip E. Bourne; Scooter Willis* <br/>
+[Bioinformatics (2012) 28 (20): 2693-2695.](http://bioinformatics.oxfordjournals.org/content/28/20/2693) <br/>
+[![doi](https://img.shields.io/badge/doi-10.1093%2Fbioinformatics%2Fbts494-blue.svg?style=flat)](http://bioinformatics.oxfordjournals.org/content/28/20/2693) [![pubmed](https://img.shields.io/badge/pubmed-22877863-blue.svg?style=flat)](http://www.ncbi.nlm.nih.gov/pubmed/22877863)

--- a/_includes/citation-2017.md
+++ b/_includes/citation-2017.md
@@ -1,0 +1,4 @@
+**BioJava-ModFinder: identification of protein modifications in 3D structures from the Protein Data Bank**<br/>
+*Jianjiong Gao, Andreas Prlić, Chunxiao Bi, Wolfgang F Bluhm, Dimitris Dimitropoulos, Dong Xu, Philip E Bourne, Peter W Rose* <br/>
+[Bioinformatics (2017) 33 (13): 2047–2049.](https://academic.oup.com/bioinformatics/article/33/13/2047/3002764) <br/>
+[![doi](https://img.shields.io/badge/doi-10.1093%2Fbioinformatics%2btx101-blue.svg?style=flat)](https://academic.oup.com/bioinformatics/article/33/13/2047/3002764) [![pubmed](https://img.shields.io/badge/pubmed-28334105-blue.svg?style=flat)](http://www.ncbi.nlm.nih.gov/pubmed/28334105)

--- a/_includes/citation.md
+++ b/_includes/citation.md
@@ -1,4 +1,0 @@
-**BioJava: an open-source framework for bioinformatics in 2012**<br/>
-*Andreas Prlic; Andrew Yates; Spencer E. Bliven; Peter W. Rose; Julius Jacobsen; Peter V. Troshin; Mark Chapman; Jianjiong Gao; Chuan Hock Koh; Sylvain Foisy; Richard Holland; Gediminas Rimsa; Michael L. Heuer; H. Brandstatter-Muller; Philip E. Bourne; Scooter Willis* <br/>
-[Bioinformatics (2012) 28 (20): 2693-2695.](http://bioinformatics.oxfordjournals.org/content/28/20/2693.abstract) <br/>
-[![doi](https://img.shields.io/badge/doi-10.1093%2Fbioinformatics%2Fbts494-blue.svg?style=flat)](http://bioinformatics.oxfordjournals.org/content/28/20/2693.abstract) [![pubmed](https://img.shields.io/badge/pubmed-22877863-blue.svg?style=flat)](http://www.ncbi.nlm.nih.gov/pubmed/22877863)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,26 +1,19 @@
 <!-- Header -->
 <header id="header"{% if page.layout == 'landing' %} class="alt"{% endif %}>
-  <h1><a href="{{ site.baseurl }}/index.html"><img src="{{ site.baseurl }}/images/logo/logo_100.png"/></a></h1>
+  <h1><a href="{{ site.baseurl }}/index.html"><img src="{{ site.baseurl }}/images/logo/logo_800.png" height="20" /></a></h1>
   <nav id="nav">
     <ul>
       <li class="special">
         <a href="#menu" class="menuToggle"><span>Menu</span></a>
         <div id="menu">
           <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="https://github.com/biojava/biojava">Github</a></li>
-            {% for my_page in site.pages %}
-              {% if my_page.title and my_page.menu == 'main' %}
-            <li>{{ my_page.categories | join ' ' }}<a href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a></li>
-              {% endif %}
-            {% endfor %}
-            {% for my_page in site.wiki %}
-              {% if my_page.title and my_page.menu %}
-            <li>{{ my_page.categories | join ' ' }}<a href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a></li>
-              {% endif %}
-            {% endfor %}
-            <li><a href="{{ "/docs/api4.2.1/index.html" | prepend: side.baseurl }}">Javadoc API (4.2.1)</a></li>
-            <li><a href="{{ "/docs/api1.9.1/index.html" | prepend: side.baseurl }}">Javadoc API (1.9.1)</a></li>
+            <li><a href="{{ site.baseurl }}/index.html">Home</a></li>
+            <li><a href="{{ site.baseurl }}/wiki/About">About</a></li>
+            <li><a href="{{ site.baseurl }}/wiki/BioJava%3AGetStarted">Get started</a></li>
+            <li><a href="{{ site.baseurl }}/wiki/Documentation">Documentation</a></li>
+            <li><a href="{{ site.baseurl }}/wiki">Wiki pages</a></li>
+            <li><a href="{{ site.baseurl }}/wiki/GetInvolved">Get involved</a></li>
+            <li><a href="{{ site.baseurl }}/wiki/FAQs">FAQs</a></li>
           </ul>
         </div>
       </li>

--- a/_wiki/AboutBioJava.md
+++ b/_wiki/AboutBioJava.md
@@ -1,0 +1,30 @@
+---
+title: About BioJava
+permalink: wiki/About
+---
+
+The BioJava project
+-------------------
+
+BioJava is an open-source project dedicated to providing a Java framework for processing biological data. It provides analytical and statistical routines, parsers for common file formats and allows the manipulation of biological sequences and 3D structures. The main goal of the project is to facilitate rapid application development for bioinformatics.
+
+We have a <a href="https://wikipedia.org/wiki/BioJava">Wikipedia page</a> (of course!) in case you would like to know more about the project.
+
+Articles
+--------
+
+If you use BioJava, please cite:
+
+  {% capture my-citation %}{% include citation-2012.md %}{% endcapture %}
+  {{ my-citation | markdownify }}
+
+Other articles include:
+
+  {% capture my-citation %}{% include citation-2017.md %}{% endcapture %}
+  {{ my-citation | markdownify }}
+
+  {% capture my-citation %}{% include citation-2008.md %}{% endcapture %}
+  {{ my-citation | markdownify }}
+
+  {% capture my-citation %}{% include citation-2000.md %}{% endcapture %}
+  {{ my-citation | markdownify }}

--- a/_wiki/BioJava_CookBook4.0.md
+++ b/_wiki/BioJava_CookBook4.0.md
@@ -1,7 +1,7 @@
 ---
-title: BioJava:CookBook4.0
+title: BioJava CookBook
 permalink: wiki/BioJava%3ACookBook4.0/
-menu: main
+#menu: main
 ---
 
 BioJava Cookbook for release 4.\*
@@ -22,8 +22,6 @@ bit bloated.
 If you have any suggestions, questions or comments contact the [biojava
 mailing list](mailto:biojava-l@biojava.org). To subscribe to this list
 go [here](http://biojava.org/mailman/listinfo/biojava-l)
-
-**Please cite:**
 
 Tutorial
 --------
@@ -172,5 +170,4 @@ biojava-core*
 Legacy 1.8.x CookBook
 ---------------------
 
-The CookBook for the legacy 1.8.x code base is available from
-<BioJava:CookBookLegacy>.
+The CookBook for the legacy 1.8.x code base is available from [here](/wiki/BioJava:CookBookLegacy "wikilink").

--- a/_wiki/BioJava_GetStarted.md
+++ b/_wiki/BioJava_GetStarted.md
@@ -1,5 +1,5 @@
 ---
-title: BioJava:GetStarted
+title: Get Started
 permalink: wiki/BioJava%3AGetStarted
 ---
 
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 BioJava will run on any computer with a Java virtual machine complying
-to the Java 2 Standard Edition (J2SE) 1.6 (or later) specifications.
+to the Java specifications.
 Java implementations for Linux, Windows, and Solaris are available to
 download from [Oracle's java
 website](http://www.oracle.com/technetwork/java/). Recent versions of
@@ -15,48 +15,43 @@ MacOS X include a suitable Java implementation as standard. Java is also
 available on many other platforms: if in doubt, contact your vendor.
 BioJava binaries are distributed in .jar (Java ARchive) format.
 
-You can get the latest version of BioJava3+ from the download page
-[BioJava (v) (requires Java 1.6+)](/wiki/BioJava:Download "wikilink").
+Obtain BioJava
+--------------
 
-You can get the latest version of BioJava-legacy (a.k.a. BioJava1) from
-the download page [BioJava1 (v) (requires Java
-1.5+)](/wiki/BioJava:Download_{{site.release.legacy}} "wikilink").
+BioJava is open-source and entirely hosted on [GitHub](https://github.com/biojava/biojava). You can check the code, submit issues and pull requests and download latest and past release binaries from GitHub.
 
-You can also integrate BioJava with NetBeans IDE. To find out how follow
-this [link](/wiki/How_to_integrate_BioJava_in_NetBeans_IDE "wikilink").
+You can manually download the latest version of BioJava ({{site.release.version}}), which requires Java 1.8+, from the [GitHub releases page](https://github.com/biojava/biojava/releases), but continue reading this article for a more convenient solution to integrate BioJava into your project.
 
-A step by step guide on 'How to integrate BioJava in Netbeans IDE' is
-[here](/wiki/BioJava-Installation_Guide.png "wikilink").
+For instructions on how to obtain the BioJava-legacy (a.k.a. BioJava1), which requires Java 1.5+, follow [this link](BioJava%3AGetStartedLegacy) or check the [biojava-legacy](https://github.com/biojava/biojava-legacy) project on GitHub.
 
-Maven
------
+Quick Installation
+------------------
 
 BioJava uses [Maven](http://maven.apache.org/) as a build and
-distribution system. If you are new to Maven, take a look at the
+distribution system. If you are new to Maven and want to find out more about it (although most details are not required for using BioJava), take a look at the
 [Getting Started with
 Maven](http://maven.apache.org/guides/getting-started/index.html) guide.
 
-BioJava, as of release 4.0.0 is available through Maven Central.
+BioJava is available through [Maven Central](https://mvnrepository.com/artifact/org.biojava), so if you are using Maven to build your Java project you can import BioJava by adding the following XML to your project pom.xml file:
 
-You can add the BioJava repository by adding the following XML to your
-project pom.xml file:
+```xml
+    <dependencies>
+      <dependency>
+        <groupId>org.biojava</groupId>
+        <artifactId>biojava-core</artifactId>
+        <version>{{site.release.version}}</version>
+      </dependency>
+      <!-- other biojava jars as needed -->
+    </dependencies>
+```
+
+More options can be found in the [README](https://github.com/biojava/biojava) of the GitHub repository.
 
 
-            <dependencies>
-                    ...
-                    <dependency>
-                            <groupId>org.biojava</groupId>
-                            <artifactId>biojava-core</artifactId>
-                            <version>{{site.release.version}}</version>
-                    </dependency>
-                    <!-- other biojava jars as needed -->
-            </dependencies>
+Manual Installation
+-------------------
 
-
-Installation
-------------
-
-None of these .jar files need to be unpacked for normal use -- simply
+None of the BioJava .jar files need to be unpacked for normal use - simply
 place them in a convenient directory.
 
 To use BioJava, add the required JAR files to your CLASSPATH environment
@@ -79,10 +74,7 @@ below).
 Building your own
 -----------------
 
-If you want to modify BioJava, you can obtain a copy of the source code
-from the download areas. Source releases are distributed in .tar.gz
-format. You can also obtain up-to-the-minute source code via either the
-[Maven repository](http://biojava.org/download/maven/) or from
-[github](Get source "wikilink").
+If you want to modify BioJava, you can clone or fork the GitHub repository or obtain the source code from any of the previous releases from the [releases page](https://github.com/biojava/biojava/releases).
+Source releases are distributed in .tar.gz format.
 
-BioJava is now built using [Apache Maven](http://maven.apache.org/).
+If you think your modifications can benefit others do not hesitate to submit a [pull request on GitHub](https://github.com/biojava/biojava/pulls). We always welcome new contributions. Here is how you can [get involved]({{site.baseurl}}/getinvolved.html).

--- a/_wiki/BioJava_Tutorial.md
+++ b/_wiki/BioJava_Tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: BioJava:Tutorial
 permalink: wiki/BioJava%3ATutorial
-menu: main
+#menu: main
 ---
 
 BioJava 4 tutorial:

--- a/_wiki/FAQs.md
+++ b/_wiki/FAQs.md
@@ -1,0 +1,14 @@
+---
+title: Frequently Asked Questions
+permalink: wiki/FAQs
+---
+
+**Q: Which macromolecular structure formats does BioJava support?**  
+A: Currently BioJava supports parsing macromolecular structures in [PDB](https://www.rcsb.org/pdb/static.do?p=file_formats/pdb/index.html), [MMCIF](https://www.rcsb.org/pdb/static.do?p=file_formats/mmcif/index.html) and, as of version 5+, [MMTF](http://mmtf.rcsb.org/).
+The library also allows conversion between the formats through the same internal representation as `Structure` objects.
+
+**Q: How often are new versions of BioJava released?**  
+A: There is not a fixed schedule for BioJava releases. Minor versions are released when there are important bug fixes to include, and as a fact we have released two major versions in the last six years.
+
+**Q: I love the library, how can I support you?**  
+A: Thanks! We are simple people, so just consider giving us a star in the [GitHub repository](https://github.com/biojava/biojava/stargazers) and [citing the project]({{site.baseurl}}/about.html) if it was useful in your research.

--- a/_wiki/GetInvolved.md
+++ b/_wiki/GetInvolved.md
@@ -1,0 +1,22 @@
+---
+title: Get involved
+permalink: wiki/GetInvolved
+---
+
+Become a contributor
+--------------------
+
+BioJava is made possible thanks to its diverse [developer community](https://github.com/biojava/biojava/graphs/contributors).
+We always welcome new contributors, no matter the type or extent of the contributions.
+
+If you already have some ideas or suggestions to improve the library, submit a new [issue](https://github.com/biojava/biojava/issues) or [pull request](https://github.com/biojava/biojava/pulls) on GitHub.
+
+Alternatively, you can explore some of the known [bugs](https://github.com/biojava/biojava/issues?q=is%3Aissue+is%3Aopen+label%3Abug) that need fixing or [feature requests](https://github.com/biojava/biojava/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+feature%22) from other users.
+If you are unsure, contact us and we might be able to point out the ones suitable for newcomers and students.
+
+Stay tuned
+----------
+
+There are two channels to contact the BioJava community and stay in touch (it is that simple!):  
+1. Watch (and star!) the main [BioJava GitHub](https://github.com/biojava/biojava) repository and participate in the discussions.  
+2. Subscribe to the biojava-l mailing list [here](http://lists.open-bio.org/mailman/listinfo/biojava-l) and send an e-mail to [biojava-l@biojava.org](mailto:biojava-l@biojava.org).

--- a/_wiki/documentation.md
+++ b/_wiki/documentation.md
@@ -1,0 +1,31 @@
+---
+title: Documentation
+permalink: wiki/Documentation
+menu: main
+---
+
+There are three main sources of documentation for BioJava: the tutorial, the cookbook and the Javadoc APIs. The most appropiate one will depend on you needs. As a rule of thumb, the tutorial is best suited for beginners looking for an introduction to the general structure and features of the library, while the cookbook is intended for more advanced users looking for a specific use case. Another useful guide are the demos in each BioJava module.
+
+The BioJava tutorial
+--------------------
+
+The goal of the tutorial is to give an educational introduction into some of the features that are provided by BioJava and each of its modules.
+
+The tutorial is being hosted on GitHub at [https://github.com/biojava/biojava-tutorial](https://github.com/biojava/biojava-tutorial).
+
+The BioJava CookBook
+--------------------
+
+The CookBook is a collection of common bioinformatics problems solved using BioJava explained step by step. The CookBook was included in the mediawiki pages and it has been migrated to the current website.
+You can access it [here](BioJava%3ACookBook4.0).
+
+The Javadoc APIs
+----------------
+
+And finally the collection of Javadoc APIs. The link will take you to the generated HTML version of the Javadoc. You can choose from the following versions:
+
+- [Javadoc API for BioJava 5.0.0]({{site.baseurl}}/docs/api5.0.0/index.html)
+- [Javadoc API for BioJava 4.2.9]({{site.baseurl}}/docs/api4.2.9/index.html)
+- [Javadoc API for BioJava 4.2.1]({{site.baseurl}}/docs/api4.2.1/index.html)
+- [Javadoc API for BioJava 4.2.0]({{site.baseurl}}/docs/api4.2.0/index.html)
+- [Javadoc API for BioJava legacy 1.9.1]({{site.baseurl}}/docs/api1.9.1/index.html)

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@ layout: landing
 					<section id="banner">
 						<div class="inner">
 							<h2>{{ site.title }}</h2>
-							<p>{{ site.description | markdownify }}</p>
+							<p>{{ site.description | markdownify }}</p><br>
 							<ul class="actions">
-								<li><a href="https://github.com/biojava/biojava/" class="button special">Get the Source</a></li>
+								<li><a href="wiki/BioJava%3AGetStarted" class="button special">Get started</a></li>
 							</ul>
 						</div>
 						<a href="#one" class="more scrolly">Learn More</a>
@@ -17,17 +17,10 @@ layout: landing
 					<section id="one" class="wrapper style1 special">
 						<div class="inner">
 							<header class="major">
-								<h2>BioJava is open source<br />
-								</h2>
-								<p>It's hosted, developed, and maintained on GitHub.<br/>
-								  </p>
-								    <a href="https://github.com/biojava/biojava" class="button big">View the GitHub project</a>
+								<h2>Open source</h2>
+								<p>The project is hosted, developed, and maintained on GitHub.</p>
+								    <a href="https://github.com/biojava/biojava" class="button big">GitHub project</a>
 							</header>
-							<ul class="icons major">
-								<li><span class="icon fa-diamond major style1"><span class="label">Current release: {{ site.release.version }}</span></span></li>
-								<li><span class="icon fa-heart-o major style2"><span class="label">Ipsum</span></span></li>
-								<li><span class="icon fa-code major style3"><span class="label">Dolor</span></span></li>
-							</ul>
 						</div>
 					</section>
 
@@ -35,39 +28,23 @@ layout: landing
 					<section id="two" class="wrapper alt style2">
 						<section class="spotlight">
 							<div class="image"><img src="images/4hhb.png" alt="" /></div><div class="content">
-								<h2>Protein Structure Modules<br />
-								</h2>
-								<p>provide an API that allow to</p>
-								<ul>
-								  <li>Maintain local installations of PDB</li>
-								  <li>Load structures and manipulate them</li>
-								  <li>Perform standard analysis such as sequence and structure alignments</li>
-								  <li>Visualize structures</li>
-								</ul>
+								<h2>Protein structures</h2>
+								<p>BioJava provides an API to maintain local installations of the PDB, load and manipulate structures, perform standard analysis such as sequence and structure alignments and visualize them in 3D.</p>
 
 							</div>
 						</section>
 						<section class="spotlight">
 							<div class="image"><img src="images/1d68.png" alt="" /></div><div class="content">
-								<h2>Biological Sequences<br />
-								</h2>
-								<p>BioJava allows to</p>
-								<ul>
-								  <li>Perform basic operations on biological sequences</li>
-								  <li>Read and Write popular sequence file formats</li>
-								  <li>Translate DNA sequences into protein sequences</li>
-								</ul>
+								<h2>Biological sequences</h2>
+								<p>BioJava supports reading and writing popular sequence file formats, translating DNA sequences into proteins and other common bioinformatics routines.</p>
 							</div>
 						</section>
 						<section class="spotlight">
 							<div class="image"><img src="images/1ihm.png" alt="" /></div><div class="content">
 								<h2>Please cite<br />
 								</h2>
-								<p>
-								  {% capture my-citation %}{% include citation.md %}{% endcapture %}
+								  {% capture my-citation %}{% include citation-2012.md %}{% endcapture %}
 								  {{ my-citation | markdownify }}
-
-								</p>
 							</div>
 						</section>
 					</section>
@@ -76,19 +53,18 @@ layout: landing
 					<section id="three" class="wrapper style1 special">
 						<div class="inner">
 							<header class="major">
-							  <h2>Mailing list</h2>
+							  <h2>Get in touch</h2>
 							  <p>
-							    Questions, comments, and communications regarding BioJava can be made either on github or on the BioJava mailing list:
+							    Questions, comments, and communications regarding BioJava can be done either on <a href="https://github.com/biojava/biojava/issues">
+								<span class="label">GitHub</span></a> or through the <a href="http://lists.open-bio.org/mailman/listinfo/biojava-l">
+								<span class="label">BioJava mailing list</span></a>. Subscribe to stay up to date!
 							    </p>
 							</header>
 							  <ul class="icons major">
-							    <li><span class="icon fa-envelope-o major style1"></span>
-								<a href="/wiki/BioJava:MailingLists/">
-								  <span class="label">biojava-l</span>
-							        </a>  general discussion list
-							    </li>
-							  </ul>
-
+							    <li><span class="icon fa-envelope-o major style1"></span></li>
+									<li><span class="icon fa-heart-o major style2"></span></li>
+								<li><span class="icon fa-code major style3"></span></li>
+								</ul>
 
 						</div>
 						</section>
@@ -98,23 +74,24 @@ layout: landing
 							<ul class="features">
 								<li class="icon fa-graduation-cap">
 									<h3>Tutorial</h3>
-									<p>The tutorial offers an introduction into some of the features that are provided by BioJava.</p>
-									<a href="https://github.com/biojava/biojava-tutorial" class="button">tutorial</a>
+									<p>The tutorial offers an introduction into some of the features provided by BioJava.</p>
+									<a href="https://github.com/biojava/biojava-tutorial" class="button">Tutorial</a>
 								</li>
 								<li class="icon fa-rocket">
-									<h3>Cookbook</h3>
-									<p>The Cookbook provides simple coding recipes that follow a "How do I ..." approach.</p>
-									<a href="http://biojava.org/wiki/BioJava:CookBook4.0/" class="button">Cookbook</a>
+									<h3>CookBook</h3>
+									<p>The Cookbook provides simple coding recipes to common bioinformatics problems using BioJava.</p>
+									<a href="wiki/BioJava%3ACookBook4.0" class="button">Cookbook</a>
 								</li>
 								<li class="icon fa-code">
 									<h3>Javadoc API</h3>
-									<p>The Javadocs for the current BioJava release</p>
+									<p>The Javadocs for the current BioJava {{site.release.version}} release.</p>
 									<a href="docs/api" class="button">Javadoc API</a></br>
 
 								</li>
 								<li class="icon fa-globe">
-									<h3>Current release: {{ site.release.version }}</h3>
-									<p>BioJava is available from Maven Central</p>
+									<h3>Release {{ site.release.version }}</h3>
+									<p>BioJava is available from Maven Central.</p>
+									<a href="https://mvnrepository.com/artifact/org.biojava" class="button">Maven Central</a></br>
 								</li>
 								<li class="icon fa-heart-o">
 									<h3>Wiki</h3>
@@ -123,7 +100,7 @@ layout: landing
 								</li>
 								<li class="icon fa-flag-o">
 									<h3>Legacy Javadoc API</h3>
-									<p>The Javadocs for legacy 1.x BioJava.</p>
+									<p>The Javadocs for BioJava legacy 1.x versions.</p>
 									<a href="docs/api1.9.1/" class="button">View 1.9.1 API</a>
 								</li>
 							</ul>
@@ -134,12 +111,12 @@ layout: landing
 					<section id="cta" class="wrapper style4">
 						<div class="inner">
 							<header>
-								<h2><img src="/images/logo/logo_favicon_65.png" style="vertical-align:middle"/> Learn More</h2>
-								<p>Here a couple of pointers for how to get started</p>
+								<h2><img src="/images/logo/logo_favicon_250.png" height="60" style="vertical-align:middle"/> Learn More</h2>
+								<p>Here a couple of pointers to get you started</p>
 							</header>
 							<ul class="actions vertical">
-								<li><a href="wiki/Get_source/" class="button fit special">Get the Code</a></li>
-								<li><a href="wiki/BioJava:GetStarted/" class="button fit">Get Started</a></li>
+								<li><a href="wiki/BioJava%3AGetStarted" class="button fit special">Get started</a></li>
+								<li><a href="https://github.com/biojava/biojava" class="button fit">Get the source</a></li>
 							</ul>
 						</div>
 					</section>

--- a/wiki.html
+++ b/wiki.html
@@ -1,24 +1,22 @@
 ---
 layout: page
-title: Wiki Pages
+title: Wiki pages
 menu: main
 ---
 
 <div class="home">
 
-  <p>The following pages have been imported from the legacy mediawiki instance</p>
+  <p>The following pages include content related to BioJava created since the launch of the project. The content has been imported from the legacy mediawiki instance and no new pages have been added.</p>
+  <p>We did out best to preserve the information, but be aware that some links and content might be outdated or no longer available. We are in the process of organizing and cleaning them up.</p>
 
-  {% for my_page in site.wiki %}
   <p>
     <ul>
+      {% for my_page in site.wiki %}
       <li>
         {{ my_page.categories }} <a href="{{ site.baseurl }}{{ my_page.url }}">{{ my_page.title }}</a>
       </li>
+      {% endfor %}
     </ul>
   </p>
-  {% endfor %}
-
-
-
 
 </div>


### PR DESCRIPTION
I have been working on improving the BioJava website by adding more structure to the menu and fixing many of the broken links and outdated information. Hopefully the website is now cleaner!

I more or less kept a log of the changes, so maybe it is useful to review them:

- Website: add link to javadoc 5.0 (replace the 4.2.1)
- Improve the navigation of the website
- Add all references and the documentation
- Add FAQs and About sections to the website

Fix broken links:
* Home and get started from the main menu
* Mailing list should be http://lists.open-bio.org/mailman/listinfo/biojava-l
* Menu should not directly point to GitHub
* Reference to legacy broken at the end of the cookbook page https://biojava.org/wiki/BioJava:CookBook4.0/
* Download page is broken and just says redirect - use the GitHub releases page: https://github.com/biojava/biojava/releases
* Link to Maven Central: https://mvnrepository.com/artifact/org.biojava
* Adapt the Get started page to current needs
* Get source links should point to GitHub only
* Legacy project https://github.com/biojava/maven-repo and https://github.com/biojava/biojava-legacy
* Link to the developers: https://github.com/biojava/biojava/graphs/contributors

MENU
* Home: the main scroll down page with highlights
* About
    * Project description
    * Articles and citation
    * Wikipedia
* Get started
    * Java requirements
    * Source code
    * Releases
    * Maven installation
    * Contributing
* Documentation
    * Tutorial
    * Cookbook
    * Javadocs
* Get involved
    * Mailing list
    * Github Issues and PR
    * Starter issues for newcomers (we used to have a tag for this, but seems to have been deleted...)
* FAQs
    * Port some of the useful Q&A from the mailing lists and GitHub (I just added three to start it)